### PR TITLE
Update webpack-cli version (resolves error)

### DIFF
--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -23,7 +23,7 @@
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "5.1.1",
     "util": "0.12.3",
-    "webpack-cli": "4.5.0",
+    "webpack-cli": "4.9.0",
     "webpack-dev-server": "^3.11.2",
     "webpack": "5.24.4"
   },


### PR DESCRIPTION
There is an error that occurs when following the local development quickstart:
https://sdk.dfinity.org/docs/quickstart/local-quickstart.html
Error looks like, (on npm start):
 [webpack-cli] TypeError: options.forEach is not a function

This fixes the error